### PR TITLE
Add ADMIN and DOCTOR roles to User entity

### DIFF
--- a/migrations/Version20260505141317.php
+++ b/migrations/Version20260505141317.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260505141317 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user ADD role VARCHAR(20) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user DROP role');
+    }
+}

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -49,6 +49,7 @@ final class UserController extends AbstractController
                         'name' => $user->getName(),
                         'age' => $user->getAge(),
                         'username' => $user->getUsername(),
+                        'role' => $user->getRole(),
                     ]
                 ],
                 Response::HTTP_OK
@@ -85,6 +86,7 @@ final class UserController extends AbstractController
                 'age' => $user->getAge(),
                 'speciality' => $user->getSpeciality(),
                 'username' => $user->getUsername(),
+                'role' => $user->getRole(),
             ]
         ], Response::HTTP_OK);
     }
@@ -111,6 +113,9 @@ final class UserController extends AbstractController
         if (isset($data['password']) && !empty($data['password'])) {
             $user->setPassword($data['password']);
         }
+        if (isset($data['role']) && in_array($data['role'], ['ADMIN', 'DOCTOR'])) {
+            $user->setRole($data['role']);
+        }
 
         $em->flush();
 
@@ -124,6 +129,7 @@ final class UserController extends AbstractController
                 'age' => $user->getAge(),
                 'speciality' => $user->getSpeciality(),
                 'username' => $user->getUsername(),
+                'role' => $user->getRole(),
             ]
         ], Response::HTTP_OK);
     }
@@ -147,6 +153,14 @@ final class UserController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
+        $role = $data['role'] ?? 'DOCTOR';
+        if (!in_array($role, ['ADMIN', 'DOCTOR'])) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Invalid role. Must be ADMIN or DOCTOR'
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
         $user = new User();
         $user->setName($data['name']);
         $user->setSurname($data['surname']);
@@ -154,6 +168,7 @@ final class UserController extends AbstractController
         $user->setSpeciality($data['speciality']);
         $user->setUsername($data['username']);
         $user->setPassword($data['password']);
+        $user->setRole($role);
 
         $userRepository->save($user, true);
 
@@ -167,6 +182,7 @@ final class UserController extends AbstractController
                 'age' => $user->getAge(),
                 'speciality' => $user->getSpeciality(),
                 'username' => $user->getUsername(),
+                'role' => $user->getRole(),
             ]
         ], Response::HTTP_CREATED);
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -31,6 +31,9 @@ class User
     #[ORM\Column(length: 50)]
     private ?string $password = null;
 
+    #[ORM\Column(length: 20)]
+    private string $role = 'DOCTOR';
+
     public function getId(): ?int
     {
         return $this->id;
@@ -113,6 +116,18 @@ class User
     public function setPassword(string $password): static
     {
         $this->password = $password;
+
+        return $this;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function setRole(string $role): static
+    {
+        $this->role = $role;
 
         return $this;
     }


### PR DESCRIPTION
- Add role field to User entity with default value DOCTOR
- Add getter and setter for role
- Return role in login, get, create and update responses
- Validate role on create and update (must be ADMIN or DOCTOR)
- Run migration to add role column to user table